### PR TITLE
Fixing the network on windows host

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,31 +10,54 @@ WORKSPACE_VM_BOX_WITH_GUI_URL = "https://atlas.hashicorp.com/box-cutter/ubuntu14
 WORKSPACE_VM_BOX_NO_GUI = "ubuntu/trusty64"
 WORKSPACE_VM_BOX_NO_GUI_URL = "http://files.vagrantup.com/trusty64.box"
 
+##################################################
+
 WS_IP_FIRST_24BITS = "192.168.10."
+WS_NETWORK_NAME = "vagrant_ws"
+
 WS_IP_SPACE_GENERIC_START = 2
+
 WS_IP_SPACE_YARC_SERVER_START = 10
+N_YARC_Servers = 3
+
 WS_IP_SPACE_YARC_CLIENT_START = 20
+N_YARC_Clients =3
+
 WS_IP_SPACE_CPP_START = 25
+N_CPP = 1
+
 WS_IP_SPACE_ERL_START = 30
+N_ERL = 1
+
 WS_IP_SPACE_SCALA_START = 35
+N_SCALA = 1
+
 WS_IP_SPACE_MYSQL_START = 40
+
 WS_IP_SPACE_HAPROXY_START = 45
+
 WS_IP_SPACE_SHELL_START = 50
+
 WS_IP_SPACE_PERL_START = 51
+
 # NOTE: ! Do not use those Starts over 99 - we are re-using it for port forwarding.
+
+##################################################
+
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Simplest generic box, with only shell provisioning  
-  machine_id = 1
-  config.vm.define "gen#{machine_id}", autostart: false do |box|
+  config.vm.define "gen1", autostart: false do |box|
+    machine_id = 1
     box.vm.box = "#{WORKSPACE_VM_BOX_WITH_GUI}"
     box.vm.box_url = "#{WORKSPACE_VM_BOX_WITH_GUI_URL}"
 
     #  box.vm.network :forwarded_port, guest: 22, host: "21#{WS_IP_SPACE_GENERIC_START+machine_id}"
     box.ssh.forward_agent = true
     box.vm.host_name = "gen#{machine_id}.vm"
-    box.vm.network :private_network, ip: "#{WS_IP_FIRST_24BITS}#{WS_IP_SPACE_GENERIC_START+machine_id}"
+    box.vm.network :private_network, ip: "#{WS_IP_FIRST_24BITS}#{WS_IP_SPACE_GENERIC_START+machine_id}", netmask: "255.255.255.0", virtual_box__intnet: "{#WS_NETWORK_NAME}"
+#    box.vm.network "private_network", ip: "#{WS_IP_FIRST_24BITS}#{WS_IP_SPACE_GENERIC_START+machine_id}", netmask: "255.255.255.0", virtual_box__intnet: true
     box.vm.synced_folder  "projects", "/projects"
 
     box.vm.provider "virtualbox" do |vb|
@@ -50,20 +73,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.provision "shell", inline: <<-SHELL
       apt-get install dos2unix 
-      /vagrant/scripts/bootstrap.sh 
+      dos2unix -n /vagrant/scripts/bootstrap.sh ~/bootstrap.sh
+      source ~/bootstrap.sh
     SHELL
   end
 
   # another simple one
-  machine_id = 2
-  config.vm.define "gen#{machine_id}", autostart: false do |box|
+  config.vm.define "gen2", autostart: false do |box|
+    machine_id = 2
     box.vm.box = "#{WORKSPACE_VM_BOX_WITH_GUI}"
     box.vm.box_url = "#{WORKSPACE_VM_BOX_WITH_GUI_URL}"
 
     #  box.vm.network :forwarded_port, guest: 22, host: "21#{WS_IP_SPACE_GENERIC_START+machine_id}"
     box.ssh.forward_agent = true
     box.vm.host_name = "gen#{machine_id}.vm"
-    box.vm.network :private_network, ip: "#{WS_IP_FIRST_24BITS}#{WS_IP_SPACE_GENERIC_START+machine_id}"
+    box.vm.network :private_network, ip: "#{WS_IP_FIRST_24BITS}#{WS_IP_SPACE_GENERIC_START+machine_id}", netmask: "255.255.255.0", virtual_box__intnet: "{#WS_NETWORK_NAME}"
     box.vm.synced_folder  "projects", "/projects"
 
     box.vm.provider "virtualbox" do |vb|
@@ -79,20 +103,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.provision "shell", inline: <<-SHELL
       apt-get install dos2unix 
-      /vagrant/scripts/bootstrap.sh 
+      dos2unix -n /vagrant/scripts/bootstrap.sh ~/bootstrap.sh
+      source ~/bootstrap.sh
     SHELL
   end
 
   # A more feature-rich generic box
-  machine_id = 3
-  config.vm.define "gen#{machine_id}", autostart: false do |box|
+  config.vm.define "gen3", autostart: false do |box|
+    machine_id = 3
     box.vm.box = "#{WORKSPACE_VM_BOX_WITH_GUI}"
     box.vm.box_url = "#{WORKSPACE_VM_BOX_WITH_GUI_URL}"
 
     #  box.vm.network :forwarded_port, guest: 22, host: "21#{WS_IP_SPACE_GENERIC_START+machine_id}"
     box.ssh.forward_agent = true
     box.vm.host_name = "gen#{machine_id}.vm"
-    box.vm.network :private_network, ip: "#{WS_IP_FIRST_24BITS}#{WS_IP_SPACE_GENERIC_START+machine_id}"
+    box.vm.network "private_network", ip: "#{WS_IP_FIRST_24BITS}#{WS_IP_SPACE_GENERIC_START+machine_id}", netmask: "255.255.255.0", virtual_box__intnet: "{#WS_NETWORK_NAME}", drop_nat_interface_default_route: true
     box.vm.synced_folder  "projects", "/projects"
 
     box.vm.provider "virtualbox" do |vb|
@@ -108,7 +133,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.provision "shell", inline: <<-SHELL
       apt-get install dos2unix 
-      /vagrant/scripts/bootstrap.sh 
+      dos2unix -n /vagrant/scripts/bootstrap.sh ~/bootstrap.sh
+      source ~/bootstrap.sh
     SHELL
 
     box.vm.provision "dev_generic", type: "ansible" do |ansible|
@@ -151,7 +177,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.provision "shell", inline: <<-SHELL
       apt-get install dos2unix
-      /vagrant/scripts/bootstrap.sh
+      dos2unix -n /vagrant/scripts/bootstrap.sh ~/bootstrap.sh
+      source ~/bootstrap.sh
     SHELL
   end
 
@@ -179,11 +206,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.provision "shell", inline: <<-SHELL
       apt-get install dos2unix
-      /vagrant/scripts/bootstrap.sh
+      dos2unix -n /vagrant/scripts/bootstrap.sh ~/bootstrap.sh
+      source ~/bootstrap.sh
     SHELL
   end
 
-  N_YARC_Servers = 3
   (1..N_YARC_Servers).each do |machine_id|
     config.vm.define "yser#{machine_id}", autostart: false do |box|
 
@@ -212,8 +239,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       config.vm.provision "shell", inline: <<-SHELL
-         sudo apt-get update
-      ###  sudo apt-get install -y apache2
+        apt-get install dos2unix
+        dos2unix -n /vagrant/scripts/bootstrap.sh ~/bootstrap.sh
+        source ~/bootstrap.sh
       SHELL
 
       box.vm.provision "dev_generic", type: "ansible" do |ansible|
@@ -225,7 +253,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  N_YARC_Clients =3
   (1..N_YARC_Clients).each do |machine_id|
     config.vm.define "ycli#{machine_id}", autostart: false do |box|
 
@@ -238,7 +265,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       box.vm.synced_folder  "projects", "/projects"
 
       config.vm.provision "shell", inline: <<-SHELL
-        sudo apt-get update
+        apt-get install dos2unix
+        dos2unix -n /vagrant/scripts/bootstrap.sh ~/bootstrap.sh
+        source ~/bootstrap.sh
       SHELL
 
       box.vm.provider "virtualbox" do |vb|
@@ -258,7 +287,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  N_CPP = 1
   (1..N_CPP).each do |machine_id|
     config.vm.define "sbcpp#{machine_id}", autostart: false do |box|
 
@@ -280,7 +308,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       config.vm.provision "shell", inline: <<-SHELL
-        sudo apt-get update
+        apt-get install dos2unix
+        dos2unix -n /vagrant/scripts/bootstrap.sh ~/bootstrap.sh
+        source ~/bootstrap.sh
       SHELL
 
       #box.vm.provision "dev_generic", type: "ansible" do |ansible|
@@ -299,7 +329,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  N_ERL = 1
   (1..N_ERL).each do |machine_id|
     config.vm.define "sberl#{machine_id}", autostart: false do |box|
 
@@ -324,7 +353,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       config.vm.provision "shell", inline: <<-SHELL
-        sudo apt-get update
+        apt-get install dos2unix
+        dos2unix -n /vagrant/scripts/bootstrap.sh ~/bootstrap.sh
+        source ~/bootstrap.sh
       SHELL
 
       box.vm.provision "dev_generic", type: "ansible" do |ansible|
@@ -343,7 +374,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  N_SCALA = 1
   (1..N_SCALA).each do |machine_id|
     config.vm.define "sbsc#{machine_id}", autostart: false do |box|
 
@@ -365,7 +395,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       config.vm.provision "shell", inline: <<-SHELL
-        sudo apt-get update
+        apt-get install dos2unix
+        dos2unix -n /vagrant/scripts/bootstrap.sh ~/bootstrap.sh
+        source ~/bootstrap.sh
       SHELL
 
       box.vm.provision "dev_generic", type: "ansible" do |ansible|

--- a/ansible/ansible.vmhosts
+++ b/ansible/ansible.vmhosts
@@ -1,4 +1,10 @@
 
+
+[gen_sandboxes]
+gen1 ansible_host=192.168.10.3
+gen2 ansible_host=192.168.10.4
+gen3 ansible_host=192.168.10.5
+
 [yarc_servers]
 yser1 ansible_host=192.168.10.11
 yser2 ansible_host=192.168.10.12

--- a/config/hosts_append.txt
+++ b/config/hosts_append.txt
@@ -1,0 +1,23 @@
+
+# This should sync with the ansible.vmhosts, and with the Vagrantfile.
+# It is in leu of a dns server, that hopefully will come to existance.
+
+192.168.10.3 gen1
+192.168.10.4 gen2
+192.168.10.5 gen3
+
+192.168.10.11 yser1
+192.168.10.12 yser2
+192.168.10.13 yser3
+192.168.10.14 yser4
+192.168.10.15 yser5
+
+192.168.10.21 ycli1
+192.168.10.22 ycli2
+192.168.10.23 ycli3
+192.168.10.24 ycli4
+192.168.10.25 ycli5
+
+192.168.10.31 sbcpp1
+
+192.168.10.51 sbshell1

--- a/doc/Vagrant.md
+++ b/doc/Vagrant.md
@@ -10,3 +10,48 @@
 Run ```vagrant box update``` to keep the boxes up to date and not
 need to update from within the VMs.
 
+
+#### Example customizing the box
+
+```
+1      box.vm.provider "virtualbox" do |vb|
+2        vb.gui = true
+3        vb.memory = "2048"
+4        vb.customize ["modifyvm", :id, "--vram", "16"]
+5        vb.cpus = 2
+6        vb.customize ["modifyvm", :id, "--audio", 'coreaudio']
+7      end
+```
+
+Line 6 may not work on Windows.
+
+
+
+#### Example provisioning section with shell provisioning:
+
+```
+1      config.vm.provision "shell", inline: <<-SHELL
+2        apt-get install dos2unix 
+3        dos2unix -n /vagrant/scripts/bootstrap.sh ~/bootstrap.sh
+4        source ~/bootstrap.sh
+5        sudo apt-get install -y apache2
+6      SHELL
+```
+
+Line 2 installs the file converter to remove the ```\r``` that Windows may have added.
+
+Line 5 uses ```-y``` to make sure the installer does not wait for the user entry.
+
+#### Example provisioning section with Ansible provisioning:
+
+```
+      box.vm.provision "dev_cpp", type: "ansible" do |ansible|
+         ansible.playbook = "ansible/playbooks/dev_cpp/bootstrap.yml"
+         #ansible.inventory_path = "ansible/ansible.vmhosts"
+         ansible.verbose = true
+         ansible.host_key_checking = false
+      end
+```
+
+
+

--- a/doc/Vim.md
+++ b/doc/Vim.md
@@ -2,7 +2,7 @@
 ## UNDER CONSTRUCTION
 
 
-### On Windows ###
+### On Windows
 
 There are times when you could use it on Windows. Here's how to get it:
 [http://www.vim.org/download.php](http://www.vim.org/download.php)  
@@ -10,4 +10,32 @@ There are times when you could use it on Windows. Here's how to get it:
 You'll need to add the path to it.
 
 
+### On Linux
+
+Add this to ```~/.vimrc``` to make sure the arrows work as expected:
+
+```
+set esckeys
+```
+
+I think this works too:
+
+```
+set nocp
+```
+
+This turns on the line numbers:
+
+```
+set number
+```
+
+
+Bottom line, just cut and paste this:
+
+```
+set esckeys
+set tabstop=4
+set number
+```
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,15 +8,17 @@ dos2unix -n /vagrant/scripts/init.sh tmp/init.sh
 dos2unix -n /vagrant/scripts/git.sh tmp/git.sh 
 dos2unix -n /vagrant/scripts/jdk.sh tmp/jdk.sh 
 dos2unix -n /vagrant/scripts/intellij.sh tmp/intellij.sh 
-dos2unix -n /vagrant/scripts/scala.sh tmp/scala.sh 
-chmod +x tmp/*.sh 
+dos2unix -n /vagrant/scripts/scala.sh tmp/scala.sh
+chmod +x tmp/*.sh
 
+dos2unix -n /vagrant/config/hosts_append.txt tmp/hosts_append.txt
+sudo cat tmp/hosts_append.txt >> /etc/hosts
 
 # These are optional, but for now let's throw them all into the defult set
-tmp/git.sh 
-tmp/jdk.sh 
-tmp/scala.sh 
-tmp/intellij.sh 
+#tmp/git.sh
+#tmp/jdk.sh
+#tmp/scala.sh
+#tmp/intellij.sh
 
 
 tmp/init.sh 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 
 # sync the list
-sudo apt-get -y update
+#sudo apt-get -y update
 
-# actual upgrade
-sudo apt-get -y upgrade
+# Takes too long
+## actual upgrade
+#sudo apt-get -y upgrade
+#
+
+
+echo "set esckeys" >> ~/.vimrc
+echo "set tabstop=4" >> ~/.vimrc
+echo "set number" >> ~/.vimrc
+
+echo "set esckeys" >> /home/vagrant/.vimrc
+echo "set tabstop=4" >> /home/vagrant/.vimrc
+echo "set number" >> /home/vagrant/.vimrc
 


### PR DESCRIPTION
The network setup for the generic boxes on windows host seem to be broken.
On Win 10 the static interfaces change their configuration for no apparent reasons. Seem to correlate with automatic updates of the guest additions.

This PR also adds a few tricks to run the Vagrant scripts on Windows, notably, stripping '\r' from the files.
